### PR TITLE
Added ability to filter on only games you onw in scheduled bookings

### DIFF
--- a/backend/src/services/borrowService.ts
+++ b/backend/src/services/borrowService.ts
@@ -61,7 +61,31 @@ export const listBorrows = async () => {
 		select: {
 			game: {
 				select: {
-					name: true
+					name: true,
+
+				}
+			},
+			user: true,
+			borrowStart: true,
+			borrowEnd: true,
+			status: true
+		}
+	});
+	return borrows;
+};
+
+export const listOwnGameBorrows = async (ownerId: string) => {
+	const borrows = await prisma.borrow.findMany({
+		where: {
+			game: {
+				gameOwnerId: ownerId
+			}
+		},
+		select: {
+			game: {
+				select: {
+					name: true,
+
 				}
 			},
 			user: true,

--- a/frontend/src/components/BookingsList/BookingsList.module.scss
+++ b/frontend/src/components/BookingsList/BookingsList.module.scss
@@ -1,3 +1,4 @@
+@import 'src/styles/variables';
 .bookingsList {
 	display: flex;
 	flex-wrap: wrap;
@@ -5,4 +6,17 @@
 	gap: 1rem;
 	list-style-type: none;
 	width: 100%;
+}
+
+.listPage {
+	display: flex;
+	flex-direction: row;
+	gap: 1rem;
+	padding: 0 1rem 0  1rem;
+}
+
+.showOnBox {
+	font-size: $text-normal;
+	display:inline-block;
+
 }

--- a/frontend/src/components/BookingsList/BookingsList.tsx
+++ b/frontend/src/components/BookingsList/BookingsList.tsx
@@ -2,33 +2,44 @@ import { useApiGet } from '@/src/hooks/apiHooks';
 import { ChangeEvent, FC, useState } from 'react';
 import styles from './BookingsList.module.scss';
 import BookingCard from '../BookingCard/BookingCard';
-import { useBorrowsList } from '@/src/hooks/api/borrow';
+import { useBorrowsList, useOwnBorrowsList } from '@/src/hooks/api/borrow';
+import { useUser } from '@/src/hooks/api/auth';
 
-interface BookingsListProps {}
+interface BookingsListProps {
+}
 
 const BookingsList: FC<BookingsListProps> = () => {
-	const { data, error, isLoading } = useBorrowsList();
-
+	const [showAll, setShowAll] = useState(true);
+	const { data, error, isLoading } = showAll ? useBorrowsList() : useOwnBorrowsList();
 	return (
-		<div style={{ width: 'auto' }}>
-			{isLoading ? <p>Loading...</p> : null}
+		<>
+			<div className={styles.listPage}>
+				<p className={styles.showOnBox}>
+					<input type='checkbox' onClick={() => setShowAll(!showAll)} /> Only show your own games?
+				</p>
+				<div style={{ width: 'auto' }}>
+					{isLoading ? <p>Loading...</p> : null}
 
-			{error ? <p>Error: {error.message}</p> : null}
+					{error ? <p>Error: {error.message}</p> : null}
 
-			{data ? (
-				<ul className={styles.bookingsList}>
-					{data.map((booking) => (
-						<BookingCard
-							key={`${booking.gameName}.${booking.borrowStart}.${booking.borrowEnd}`}
-							game={booking.gameName}
-							user={booking.user}
-							start={booking.borrowStart}
-							end={booking.borrowEnd}
-						/>
-					))}
-				</ul>
-			) : null}
-		</div>
+					{data ? (
+						<ul className={styles.bookingsList}>
+							{data.filter((booking) => {
+								return new Date(booking.borrowEnd).getTime() > Date.now()
+							}).map((booking) => (
+								<BookingCard
+									key={`${booking.gameName}.${booking.borrowStart}.${booking.borrowEnd}`}
+									game={booking.gameName}
+									user={booking.user}
+									start={booking.borrowStart}
+									end={booking.borrowEnd}
+								/>
+							))}
+						</ul>
+					) : null}
+				</div>
+			</div >
+		</>
 	);
 };
 

--- a/frontend/src/hooks/api/borrow.ts
+++ b/frontend/src/hooks/api/borrow.ts
@@ -73,6 +73,20 @@ export const useBorrowsList = () => {
 	);
 };
 
+export const useOwnBorrowsList = () => {
+	return useQuery<
+		{
+			gameName: string;
+			user: string;
+			borrowStart: string;
+			borrowEnd: string;
+		}[],
+		AxiosError
+	>(['ownBorrowsList'], () =>
+		axios.get('/api/v1/borrow/list/ownGames').then((res) => res.data)
+	);
+};
+
 export const useBorrow = () => {
 	return useMutation<
 		unknown,


### PR DESCRIPTION
fixes #96 
 - Adds endpoint /borrow/list/ownGames which returns bookings only on games owned by you
 - Adds a checkbox in the frontend to switch between showing all bookings and only on your games
 - Fixes a bug where scheduled bookings also showed past bookings